### PR TITLE
Added bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,17 @@
+{
+  "name": "font-mfizz",
+  "description": "Font Mfizz",
+  "version": "1.2.0",
+  "keywords": [],
+  "homepage": "http://mfizz.com/oss/font-mfizzo",
+  "dependencies": {},
+  "devDependencies": {},
+  "license": "MIT",
+  "main": [
+    "./font/font-mfizz.*"
+  ],
+  "ignore": [
+    "*/.*",
+    "bower.json"
+  ]
+}


### PR DESCRIPTION
I've added a `bower.json` for you, so you have it easier [registering Font Mfizz as a bower package](http://bower.io/docs/creating-packages/#register).

It's a little more light-weight than #2, hopefully that helps getting it merged :P