### PR TITLE
Added package.json to make font-mfizz npm installable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "font-mfizz",
+  "version": "1.0.0",
+  "description": "Font Mfizz - Vector Icons for Technology and Software Geeks ===========================================================",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fizzed/font-mfizz.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/fizzed/font-mfizz/issues"
+  },
+  "homepage": "https://github.com/fizzed/font-mfizz#readme",
+  "dependencies": {}
+}


### PR DESCRIPTION
Comes in handy if someone using browserify/webpack wants to use it. Even if you don't feel like publishing to npm registry, please consider adding this file, so mfizz can be added as dependency via git url.