### PR TITLE
Added X11 icon

### DIFF
--- a/src/svg/x11.svg
+++ b/src/svg/x11.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xml:space="preserve"
+   viewBox="0 0 100 100"
+   height="100px"
+   width="100px"
+   y="0px"
+   x="0px"
+   id="Your_Icon"
+   version="1.1"><metadata
+     id="metadata9"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs7" /><g
+     id="layer1"
+     transform="matrix(0.36793692,0,0,0.36625244,-108.77469,-123.95352)"><path
+       style="fill:#000000"
+       id="path2830"
+       d="m 296.78571,612.63003 c 0,0 104.06285,-132.7859 104.06285,-132.7859 0,0 -104.06285,-140.24982 -104.06285,-140.24982 l 67.30299,0 c 0,0 83.34749,113.48826 83.34749,113.48826 l -126.86477,159.54746 -23.78571,0 z M 417.28794,500.06578 544.11662,339.59431 c 0,0 24.45481,0 24.45481,0 L 464.47749,471.26578 c 0,0 104.09394,141.36425 104.09394,141.36425 l -67.30357,0 c 0,0 -83.97992,-112.56425 -83.97992,-112.56425 z" /></g></svg>


### PR DESCRIPTION
I believe the X11 logo falls under the purview of this project and I would like to use it alongside the other application logos in [Atom](https://atom.io/packages/file-icons). I've tweaked the logo according to the [guidelines](https://github.com/fizzed/font-mfizz/blob/master/DEVELOPMENT.md#preparing-the-artwork) and it looks great in the preview.