### PR TITLE
fixed offline mozilla link

### DIFF
--- a/src/vagrant/bootstrap-fontcustom.sh
+++ b/src/vagrant/bootstrap-fontcustom.sh
@@ -1,8 +1,5 @@
-sudo add-apt-repository -y ppa:webupd8team/java
 sudo apt-get update
-sudo apt-get -y install ruby ruby-dev fontforge ttfautohint unzip libz-dev software-properties-common python-software-properties cmake build-essential oracle-java8-installer
-echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections
-sudo update-java-alternatives -s java-8-oracle
+sudo apt-get -y install ruby ruby-dev fontforge ttfautohint unzip libz-dev software-properties-common python-software-properties cmake build-essential
 
 wget https://github.com/Jan-LucaKlees/sfnt2woff/archive/master.zip
 unzip master.zip
@@ -15,4 +12,11 @@ rm -Rf sfnt2woff-master master.zip
 
 # finally fontcustom (can we lock down specific ver?)
 echo "Install ruby gem fontcustom v1.3.8 (may take awhile)..."
-sudo gem install fontcustom -v 1.3.8
+sudo LC_CTYPE=en_US.UTF-8 LANG=en_US.UTF-8 gem install fontcustom -v 1.3.8
+
+# finish off with java 8
+sudo add-apt-repository -y ppa:webupd8team/java
+sudo apt-get update
+echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections
+sudo apt-get install -y oracle-java8-installer
+sudo update-java-alternatives -s java-8-oracle

--- a/src/vagrant/bootstrap-fontcustom.sh
+++ b/src/vagrant/bootstrap-fontcustom.sh
@@ -1,22 +1,18 @@
+sudo add-apt-repository -y ppa:webupd8team/java
 sudo apt-get update
-sudo apt-get -y install ruby ruby-dev fontforge ttfautohint unzip libz-dev software-properties-common python-software-properties
+sudo apt-get -y install ruby ruby-dev fontforge ttfautohint unzip libz-dev software-properties-common python-software-properties cmake build-essential zlib-devel oracle-java8-installer
+echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections
+sudo update-java-alternatives -s java-8-oracle
 
-# get latest build
-wget http://people.mozilla.com/~jkew/woff/woff-code-latest.zip
-unzip -d woff woff-code-latest.zip
-cd woff
-make
+wget https://github.com/Jan-LucaKlees/sfnt2woff/archive/master.zip
+unzip master.zip
+cd sfnt2woff-master
+cmake .
+sudo make install
 sudo mv sfnt2woff /usr/local/bin/
 cd ..
-rm -Rf woff woff-code-latest.zip
+rm -Rf sfnt2woff-master master.zip
 
 # finally fontcustom (can we lock down specific ver?)
 echo "Install ruby gem fontcustom v1.3.8 (may take awhile)..."
 sudo gem install fontcustom -v 1.3.8
-
-# finish off with java 8
-sudo add-apt-repository -y ppa:webupd8team/java
-sudo apt-get update
-echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections
-sudo apt-get install -y oracle-java8-installer
-sudo update-java-alternatives -s java-8-oracle

--- a/src/vagrant/bootstrap-fontcustom.sh
+++ b/src/vagrant/bootstrap-fontcustom.sh
@@ -1,6 +1,6 @@
 sudo add-apt-repository -y ppa:webupd8team/java
 sudo apt-get update
-sudo apt-get -y install ruby ruby-dev fontforge ttfautohint unzip libz-dev software-properties-common python-software-properties cmake build-essential zlib-devel oracle-java8-installer
+sudo apt-get -y install ruby ruby-dev fontforge ttfautohint unzip libz-dev software-properties-common python-software-properties cmake build-essential oracle-java8-installer
 echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections
 sudo update-java-alternatives -s java-8-oracle
 


### PR DESCRIPTION
Removed http://people.mozilla.com/~jkew/woff/woff-code-latest.zip as this link went offline.

Added missing packages cmake, build-essential to make sfnt2woff / woff2sfnt compile again.

For sfnt2woff / woff2sfnt I needed to also make changes to [this](https://github.com/ppicazo/sfnt2woff) github repo for things to function again.

This resolves #72 and #63 (though the build then still does not work, but that is another issue I'll address in a different pr)


